### PR TITLE
排掉实测的py与pandas版本坑

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Setup
 
+Before launch the script install these packages in your **Python3(<=3.6)** environment:
+
 Requirements:
 
 ```
-pandas
+pandas == 0.21.1
 numpy
 jieba
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
+pandas==0.21.1
 numpy
 jieba
 scipy


### PR DESCRIPTION
最新的python3.7会引起报错。
默认安装的最新的Pandas3会引起报错。